### PR TITLE
SS-412 get campaigns allocations group by type

### DIFF
--- a/src/utils/allocations.js
+++ b/src/utils/allocations.js
@@ -1,0 +1,63 @@
+function groupCampaignAllocationsByType({
+    channelsWithApiEnabled,
+    allocations,
+    flight_time_start,
+    flight_time_end,
+}) {
+    const campaignData = new Map();
+    const channelNames = channelsWithApiEnabled.map(channel => channel.name);
+    if (!allocations) {
+        return {};
+    }
+    for (const [index, key] of Object.keys(allocations).entries()) {
+        const periodAllocations = allocations[key].allocations;
+        for (const channel of periodAllocations) {
+            if (channelNames.includes(channel.name)) {
+                if (Array.isArray(channel.allocations)) {
+                    for (const campaignType of channel.allocations) {
+                        if (Array.isArray(campaignType.allocations)) {
+                            for (const campaign of campaignType.allocations) {
+                                campaignData.set(campaign.id, {
+                                    name: campaign.name,
+                                    type: campaignType.name,
+                                    budget:
+                                        (
+                                            campaignData.get(campaign.id) || {
+                                                budget: 0,
+                                            }
+                                        ).budget + parseFloat(campaign.budget),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    const parsedStartDate = new Date(flight_time_start)
+        .toISOString()
+        .substring(0, 10);
+    const parsedEndDate = new Date(flight_time_end)
+        .toISOString()
+        .substring(0, 10);
+
+    const campaignArray = Array.from(campaignData, ([key, value]) => ({
+        id: key,
+        ...value,
+        startDate: parsedStartDate,
+        endDate: parsedEndDate,
+    }));
+
+    const campaignDataByType = campaignArray.reduce((acc, campaign) => {
+        const { type, ...rest } = campaign;
+        if (!acc[type]) {
+            acc[type] = [];
+        }
+        acc[type].push(rest);
+        return acc;
+    }, {});
+    return campaignDataByType;
+}
+
+module.exports = { groupCampaignAllocationsByType };

--- a/tests/utils.spec.js
+++ b/tests/utils.spec.js
@@ -1,5 +1,5 @@
 const utils = require('../src/utils');
-
+const { groupCampaignAllocationsByType } = require('../src/utils/allocations');
 jest.mock('../src/models', () => ({
     User: {
         findOne: jest.fn(),
@@ -114,5 +114,145 @@ describe('utils', () => {
         expect(message).toBe(
             'Invalid allocations: Missing or invalid: [type] in allocation'
         );
+    });
+});
+// Import your function
+
+// Import your function here
+
+describe('groupCampaignAllocationsByType', () => {
+    it('should return campaign data grouped by type', () => {
+        // Sample input data
+        const channelsWithApiEnabled = [
+            { name: 'Amazon Advertising' },
+            { name: 'Google Ads' },
+        ];
+
+        // Define mock values for flight_time_start and flight_time_end
+        const flight_time_start = '2023-01-01T04:00:00.000Z';
+        const flight_time_end = '2023-02-01T04:00:00.000Z';
+        const allocations = {
+            january_2023: {
+                budget: 4000,
+                allocations: [
+                    {
+                        name: 'Amazon Advertising',
+                        allocations: [
+                            {
+                                name: 'Sponsored Display',
+                                allocations: [
+                                    {
+                                        id: '1-SEARCH-dfsdfsd',
+                                        name: 'Campaign 1',
+                                        budget: '1000',
+                                    },
+                                    {
+                                        id: '1-SEARCH-dfsdfsd1',
+                                        name: 'Campaign 2',
+                                        budget: '1000',
+                                    },
+                                ],
+                            },
+                            {
+                                name: 'Sponsored Products',
+                                allocations: [
+                                    {
+                                        id: '1-SEARCH-dfsdfsd212',
+                                        name: 'Campaign 3',
+                                        budget: '2000',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        name: 'Google Ads',
+                        allocations: [
+                            {
+                                name: 'Search Ads',
+                                allocations: [
+                                    {
+                                        id: '2-SEARCH-123',
+                                        name: 'Campaign 4',
+                                        budget: '2000',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        const expectedOutput = {
+            'Sponsored Display': [
+                {
+                    id: '1-SEARCH-dfsdfsd',
+                    name: 'Campaign 1',
+                    budget: 1000,
+                    startDate: '2023-01-01',
+                    endDate: '2023-02-01',
+                },
+                {
+                    id: '1-SEARCH-dfsdfsd1',
+                    name: 'Campaign 2',
+                    budget: 1000,
+                    startDate: '2023-01-01',
+                    endDate: '2023-02-01',
+                },
+            ],
+            'Sponsored Products': [
+                {
+                    id: '1-SEARCH-dfsdfsd212',
+                    name: 'Campaign 3',
+                    budget: 2000,
+                    startDate: '2023-01-01',
+                    endDate: '2023-02-01',
+                },
+            ],
+            'Search Ads': [
+                {
+                    id: '2-SEARCH-123',
+                    name: 'Campaign 4',
+                    budget: 2000,
+                    startDate: '2023-01-01',
+                    endDate: '2023-02-01',
+                },
+            ],
+        };
+
+        // Call the function with your sample input data
+        const result = groupCampaignAllocationsByType({
+            channelsWithApiEnabled,
+            allocations,
+            flight_time_start,
+            flight_time_end,
+        });
+
+        // Assert that the result matches the expected output
+        expect(result).toEqual(expectedOutput);
+    });
+
+    // Add more test cases to cover different scenarios
+
+    // Example test case for when allocations is null
+    it('should return an empty object when allocations is null', () => {
+        // Sample input data
+        const channelsWithApiEnabled = [
+            { name: 'Amazon Advertising' },
+            // Add more channels if needed
+        ];
+
+        // Define mock values for flight_time_start and flight_time_end
+        const flight_time_start = '2023-01-01T04:00:00.000Z';
+        const flight_time_end = '2023-02-01T04:00:00.000Z';
+        const result = groupCampaignAllocationsByType({
+            channelsWithApiEnabled,
+            allocations: null,
+            flight_time_start,
+            flight_time_end,
+        });
+
+        expect(result).toEqual({});
     });
 });


### PR DESCRIPTION
merging this PR will create a JavaScript function that takes a set of campaign allocations data and organizes it by campaign types. 
campaigns allocations organized by type are required for create amazon campaigns