### PR TITLE
SKN-548 return linked status api enabled channels

### DIFF
--- a/src/controllers/campaign.js
+++ b/src/controllers/campaign.js
@@ -21,6 +21,7 @@ const {
     checkBigQueryIdExists,
     getUsersToNotifyWithCampaigns,
     sendNotification,
+    checkSameAmountOfCampaigns,
 } = require('../utils/cronjobs');
 const { emailTemplate } = require('../templates/email');
 const { emailCampaignFail } = require('../templates/emailCampaignFail');
@@ -267,7 +268,12 @@ const getMarketingCampaignsByClient = async (req, res) => {
                     as: 'budgets',
                     limit: 1,
                     order: [['updatedAt', 'DESC']],
-                    attributes: ['periods', 'allocations', 'amazonCampaigns', 'facebookCampaigns'],
+                    attributes: [
+                        'periods',
+                        'allocations',
+                        'amazonCampaigns',
+                        'facebookCampaigns',
+                    ],
                 },
             ],
         });
@@ -283,9 +289,18 @@ const getMarketingCampaignsByClient = async (req, res) => {
             campaign.dataValues.inFlight = inFlight;
 
             // Check campaign link status
-            campaign.dataValues.linked = !checkBigQueryIdExists({
-                allocations: campaign.budgets[0].allocations,
-            }).hasUnlinkedCampaigns;
+            if (
+                campaign.budgets[0].amazonCampaigns?.length > 0 ||
+                campaign.budgets[0].facebookCampaigns?.length > 0
+            ) {
+                campaign.dataValues.linked = checkSameAmountOfCampaigns({
+                    campaign,
+                });
+            } else {
+                campaign.dataValues.linked = !checkBigQueryIdExists({
+                    allocations: campaign.budgets[0].allocations,
+                }).hasUnlinkedCampaigns;
+            }
         }
 
         res.status(200).json({
@@ -326,7 +341,13 @@ const getMarketingCampaignsById = async (req, res) => {
                     as: 'budgets',
                     limit: 1,
                     order: [['updatedAt', 'DESC']],
-                    attributes: ['id', 'periods', 'allocations', 'amazonCampaigns', 'facebookCampaigns'],
+                    attributes: [
+                        'id',
+                        'periods',
+                        'allocations',
+                        'amazonCampaigns',
+                        'facebookCampaigns',
+                    ],
                 },
             ],
         });
@@ -346,9 +367,18 @@ const getMarketingCampaignsById = async (req, res) => {
         campaign.dataValues.inFlight = inFlight;
 
         // Check campaign link status
-        campaign.dataValues.linked = !checkBigQueryIdExists({
-            allocations: campaign.budgets[0].allocations,
-        }).hasUnlinkedCampaigns;
+        if (
+            campaign.budgets[0].amazonCampaigns?.length > 0 ||
+            campaign.budgets[0].facebookCampaigns?.length > 0
+        ) {
+            campaign.dataValues.linked = checkSameAmountOfCampaigns({
+                campaign,
+            });
+        } else {
+            campaign.dataValues.linked = !checkBigQueryIdExists({
+                allocations: campaign.budgets[0].allocations,
+            }).hasUnlinkedCampaigns;
+        }
 
         res.status(200).json({
             message: 'Marketing campaign retrieved successfully',
@@ -867,11 +897,12 @@ const createMarketingCampaign = async (req, res) => {
             });
 
             // get updated data
-            const amazonCampaignsUpdated = await replaceJobIdWithAdsetInAmazonData({
-                amazonCampaigns: budget?.amazonCampaigns,
-                jobId: job.id,
-                adset: adsetResponse.data[0],
-            });
+            const amazonCampaignsUpdated =
+                await replaceJobIdWithAdsetInAmazonData({
+                    amazonCampaigns: budget?.amazonCampaigns,
+                    jobId: job.id,
+                    adset: adsetResponse.data[0],
+                });
 
             // update budget
             await Budget.update(

--- a/src/utils/cronjobs.js
+++ b/src/utils/cronjobs.js
@@ -191,7 +191,7 @@ function countCampaignAndAdsetsAmzFb({ campaigns }) {
             if (Array.isArray(campaign.adsets)) {
                 for (const adset of campaign.adsets) {
                     if (!adset.jobId) {
-                        // is it has a jobId it means it hasnt been processed yet
+                        // if it has a jobId it means it hasnt been processed yet
                         adsetCount += 1;
                     }
                 }
@@ -561,4 +561,6 @@ module.exports = {
     fetchCampaignsWithPacingsByUserId,
     updateOrInsertPacingMetrics,
     checkSameAmountOfCampaigns,
+    countCampaignsAndAdsetsInAllocations,
+    countCampaignAndAdsetsAmzFb,
 };

--- a/src/utils/cronjobs.js
+++ b/src/utils/cronjobs.js
@@ -1,4 +1,5 @@
 const {
+    Channel,
     Budget,
     CampaignGroup,
     Notification,
@@ -81,7 +82,7 @@ function checkPacingOffPace({ pacing, currentDate }) {
         const currentPeriod = allocations[formattedDate];
         // If for some reason the current period does not exist in the budget period, return null
         if (!currentPeriod) {
-            return { overPaceCampaigns: null, underPaceCampaigns: null };
+            return { overPaceCampaigns: [], underPaceCampaigns: [] };
         }
 
         // get all campaigns from the current period in a flat array
@@ -124,13 +125,96 @@ function checkPacingOffPace({ pacing, currentDate }) {
 }
 
 /**
+ * count campaigns and adsets inside of allocations
+ */
+function countCampaignsAndAdsetsInAllocations({ campaign, channelName }) {
+    let campaignCount = 0;
+    let adsetCount = 0;
+    if (Array.isArray(campaign.budgets) && campaign.budgets.length > 0) {
+        const { allocations, periods } = campaign.budgets[0];
+        const first_period = periods[0];
+
+        if (first_period) {
+            const allocationsPeriod = allocations[first_period.id];
+            if (
+                Array.isArray(allocationsPeriod.allocations) &&
+                allocationsPeriod.allocations.length > 0
+            ) {
+                for (const channel of allocationsPeriod.allocations) {
+                    if (
+                        channel.type === 'CHANNEL' &&
+                        Array.isArray(channel.allocations) &&
+                        channel.allocations.length > 0 &&
+                        channel.name === channelName
+                    ) {
+                        for (const campaignType of channel.allocations) {
+                            if (
+                                campaignType.type === 'CAMPAIGN_TYPE' &&
+                                Array.isArray(campaignType.allocations) &&
+                                campaignType.allocations.length > 0
+                            ) {
+                                campaignCount +=
+                                    campaignType.allocations.length;
+                                for (const campaign of campaignType.allocations) {
+                                    if (
+                                        campaign.type === 'CAMPAIGN' &&
+                                        Array.isArray(campaign.allocations) &&
+                                        campaign.allocations.length > 0
+                                    ) {
+                                        adsetCount +=
+                                            campaign.allocations.length;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return {
+        campaignCount,
+        adsetCount,
+    };
+}
+
+/**
+ * counts campaigns and adsets inside of amazonCampaigns, facebookCampaigns
+ */
+function countCampaignAndAdsetsAmzFb({ campaigns }) {
+    let campaignCount = 0;
+    let adsetCount = 0;
+
+    if (Array.isArray(campaigns)) {
+        campaignCount = campaigns.length;
+        for (const campaign of campaigns) {
+            if (Array.isArray(campaign.adsets)) {
+                for (const adset of campaign.adsets) {
+                    if (!adset.jobId) {
+                        // is it has a jobId it means it hasnt been processed yet
+                        adsetCount += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    return {
+        campaignCount,
+        adsetCount,
+    };
+}
+
+/**
  *  Checks if a campaign is unlinked
  */
-function checkIfCampaignIsUnlinked({ campaign }) {
+function checkIfCampaignIsUnlinked({ campaign, apiEnabledChannels = [] }) {
     const { allocations } = campaign.budgets[0];
+    console.log(campaign.id, apiEnabledChannels);
     // check if campaign does not have a bigquery_campaign_id
     const { hasUnlinkedCampaigns, campaigns } = checkBigQueryIdExists({
         allocations,
+        apiEnabledChannels,
     });
 
     const unlinkedCampaigns = campaigns.map(item => ({
@@ -145,9 +229,57 @@ function checkIfCampaignIsUnlinked({ campaign }) {
 }
 
 /**
+ * Checks if there's the same amount of campaigns in the allocations and in the amazonCampaigns, facebookCampaigns, etc
+ * also checks its adsets inside of amazonCampaigns[x].adsets, facebookCampaigns[x].adsets, etc
+ * returns true if there's the same amount of campaigns and adsets (it is linked)
+ * returns false if there's not the same amount of campaigns and adsets (it is unlinked)
+ */
+function checkSameAmountOfCampaigns({ campaign }) {
+    const { amazonCampaigns, facebookCampaigns } = campaign.budgets[0];
+
+    if (amazonCampaigns?.length > 0 || facebookCampaigns?.length > 0) {
+        const { campaignCount: amzCampaignCount, adsetCount: amzAdsetCount } =
+            countCampaignsAndAdsetsInAllocations({
+                campaign,
+                channelName: 'Amazon Advertising DSP',
+            });
+
+        const {
+            campaignCount: createdAmzCampaignsCount,
+            adsetCount: createdAmzAdsetCount,
+        } = countCampaignAndAdsetsAmzFb({
+            campaigns: amazonCampaigns,
+        });
+
+        const { campaignCount: fbCampaignCount, adsetCount: fbAdsetCount } =
+            countCampaignsAndAdsetsInAllocations({
+                campaign,
+                channelName: 'Facebook',
+            });
+
+        const {
+            campaignCount: createdFbCampaignsCount,
+            adsetCount: createdFbAdsetCount,
+        } = countCampaignAndAdsetsAmzFb({
+            campaigns: facebookCampaigns,
+        });
+
+        // it could've been validated as !== but i decided to use > just in case there
+        // are more campaigns in the amazonCampaigns or facebookCampaigns than in the allocations
+        // but that never should be the case
+        return !(
+            amzCampaignCount > createdAmzCampaignsCount ||
+            amzAdsetCount > createdAmzAdsetCount ||
+            fbCampaignCount > createdFbCampaignsCount ||
+            fbAdsetCount > createdFbAdsetCount
+        );
+    }
+}
+
+/**
  * Checks if at least a campaigns from a list of campaigns does not have a bigquery_campaign_id
  */
-function checkBigQueryIdExists({ allocations }) {
+function checkBigQueryIdExists({ allocations, apiEnabledChannels = [] }) {
     let campaignsUnlinked = [];
     for (const [index, key] of Object.keys(allocations).entries()) {
         // since every period has the same structure, we only need to check the first period
@@ -157,7 +289,9 @@ function checkBigQueryIdExists({ allocations }) {
                 if (
                     channel.type === 'CHANNEL' &&
                     Array.isArray(channel.allocations) &&
-                    channel.allocations.length > 0
+                    channel.allocations.length > 0 &&
+                    // added this line to avoid checking api enabled channels (since those are not manually linked to bigquery)
+                    !apiEnabledChannels.includes(channel.name)
                 ) {
                     for (const campaignType of channel.allocations) {
                         if (
@@ -189,7 +323,11 @@ function checkBigQueryIdExists({ allocations }) {
 /**
  * returns the users to be notified and their usernames
  */
-function getUsersToNotifyWithCampaigns({ campaigngroups, currentDate }) {
+function getUsersToNotifyWithCampaigns({
+    campaigngroups,
+    currentDate,
+    apiEnabledChannels = [],
+}) {
     let usersToNotify = {};
     let usernames = new Map();
 
@@ -197,7 +335,11 @@ function getUsersToNotifyWithCampaigns({ campaigngroups, currentDate }) {
     // in flight campaign means: A campaign with a start date in the past and an end date in the future
     for (campaign of campaigngroups) {
         // check if campaign has a user just in case (it should always have a user)
-        if (campaign.user) {
+        if (
+            campaign.user &&
+            Array.isArray(campaign.budgets) &&
+            campaign.budgets.length > 0
+        ) {
             // check if campaign is in flight
             const { inFlight } = checkInFlight({ currentDate, campaign });
             if (inFlight) {
@@ -210,6 +352,7 @@ function getUsersToNotifyWithCampaigns({ campaigngroups, currentDate }) {
                 const { unlinkedCampaigns, hasUnlinkedCampaigns } =
                     checkIfCampaignIsUnlinked({
                         campaign,
+                        apiEnabledChannels,
                     });
 
                 // if campaign is off pace or unlinked, add it to the list of campaigns to notify the user
@@ -330,6 +473,17 @@ async function fetchCampaignsWithPacings() {
 }
 
 /**
+ * Fetches all api enabled channels
+ */
+async function fetchApiEnabledChannels() {
+    return Channel.findAll({
+        where: {
+            isApiEnabled: true,
+        },
+    });
+}
+
+/**
  *  Fetches all campaigns with their pacings from the database
  */
 async function fetchCampaignsWithPacingsByUserId({ userId }) {
@@ -403,6 +557,8 @@ module.exports = {
     getUsersToNotifyWithCampaigns,
     fetchCampaignsWithBudgets,
     fetchCampaignsWithPacings,
+    fetchApiEnabledChannels,
     fetchCampaignsWithPacingsByUserId,
     updateOrInsertPacingMetrics,
+    checkSameAmountOfCampaigns,
 };

--- a/tests/cronjobs.spec.js
+++ b/tests/cronjobs.spec.js
@@ -2,6 +2,9 @@ const {
     checkIfCampaignIsOffPace,
     checkBigQueryIdExists,
     checkPacingOffPace,
+    countCampaignsAndAdsetsInAllocations,
+    countCampaignAndAdsetsAmzFb,
+    checkSameAmountOfCampaigns,
 } = require('../src/utils/cronjobs');
 
 jest.mock('../src/utils/cronjobs', () => ({
@@ -502,6 +505,208 @@ describe('Cronjobs', () => {
                 allocations,
             });
             expect(!hasUnlinkedCampaigns).toBeTruthy();
+        });
+    });
+
+    describe('countCampaignsAndAdsetsInAllocations', () => {
+        const periods = [
+            { id: 'january_2024', label: 'January 2024', days: 31 },
+        ];
+
+        const allocations = {
+            january_2024: {
+                budget: 52.275,
+                percentage: 50,
+                allocations: [
+                    {
+                        id: '8',
+                        name: 'Amazon Advertising DSP',
+                        isApiEnabled: true,
+                        deprecatedCampaignTypes: [],
+                        budget: 52.275,
+                        percentage: 100,
+                        type: 'CHANNEL',
+                        allocations: [
+                            {
+                                id: '8-Responsive eCommerce',
+                                name: 'Responsive eCommerce',
+                                budget: 52.275,
+                                percentage: 100,
+                                type: 'CAMPAIGN_TYPE',
+                                allocations: [
+                                    {
+                                        id: '8-Responsive eCommerce-b',
+                                        name: '202401|Responsive eCommerce|CCCC|CCCC|CCCC',
+                                        budget: 52.275,
+                                        percentage: 100,
+                                        goals: '',
+                                        type: 'CAMPAIGN',
+                                        allocations: [
+                                            {
+                                                id: '8-Responsive eCommerce-b-v',
+                                                name: '202401|Responsive eCommerce|CCCC|CCCC|CCCC|CCC|CCC',
+                                                budget: 52.275,
+                                                percentage: 100,
+                                                type: 'ADSET',
+                                                startDate:
+                                                    '2024-01-01T04:00:00.000Z',
+                                                endDate:
+                                                    '2024-02-01T04:00:00.000Z',
+                                                lineItemType:
+                                                    'STANDARD_DISPLAY',
+                                                frequencyCap: 'UNCAPPED',
+                                                timeUnit: '',
+                                                maximumImpressions: '',
+                                                timeUnitCount: '',
+                                                targeting: 'CCC',
+                                                format: 'CCC',
+                                            },
+                                        ],
+                                        status: 'PAUSED',
+                                        productLocation: 'SOLD_ON_AMAZON',
+                                        orderGoal: 'AWARENESS',
+                                        orderGoalKpi: 'REACH',
+                                        recurrenceTimePeriod: 'UNCAPPED',
+                                        amount: '',
+                                        autoOptimizations: 'BUDGET',
+                                        biddingStrategy: 'SPEND_BUDGET_IN_FULL',
+                                        frequencyCap: 'UNCAPPED',
+                                        timeUnit: '',
+                                        maximumImpressions: '',
+                                        timeUnitCount: '',
+                                        apiCampaign: true,
+                                        objective: 'CCCC',
+                                        nameFragment: 'CCCC',
+                                        scope: 'CCCC',
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        };
+
+        // Test Case 1: Valid input with a channel that exists
+        it('should count campaigns and adsets for a valid channel', () => {
+            const result = countCampaignsAndAdsetsInAllocations({
+                campaign: { budgets: [{ allocations, periods }] },
+                channelName: 'Amazon Advertising DSP',
+            });
+
+            expect(result.campaignCount).toBe(1);
+            expect(result.adsetCount).toBe(1);
+        });
+
+        // Test Case 2: Valid input with a channel that does not exist
+        it('should return 0 for campaign and adset count for a nonexistent channel', () => {
+            const result = countCampaignsAndAdsetsInAllocations({
+                campaign: { budgets: [{ allocations, periods }] },
+                channelName: 'Nonexistent Channel',
+            });
+
+            expect(result.campaignCount).toBe(0);
+            expect(result.adsetCount).toBe(0);
+        });
+
+        // Test Case 3: Valid input with empty allocations
+        it('should return 0 for campaign and adset count when allocations are empty', () => {
+            const result = countCampaignsAndAdsetsInAllocations({
+                campaign: { budgets: [] },
+                channelName: 'Amazon Advertising DSP',
+            });
+
+            expect(result.campaignCount).toBe(0);
+            expect(result.adsetCount).toBe(0);
+        });
+
+        // Test Case 4: Valid input with no allocations for the specified channel
+        it('should return 0 for campaign and adset count when channel allocations are empty', () => {
+            const result = countCampaignsAndAdsetsInAllocations({
+                campaign: { budgets: [] },
+                channelName: 'Nonexistent Channel',
+            });
+
+            expect(result.campaignCount).toBe(0);
+            expect(result.adsetCount).toBe(0);
+        });
+    });
+
+    describe('countCampaignAndAdsetsAmzFb', () => {
+        // Test Case 1: Valid input with a single campaign and adset
+        it('should count one campaign and one adset without jobId', () => {
+            const campaigns = [
+                {
+                    name: '8-Responsive eCommerce-b',
+                    data: { orderId: '576931729185683972' },
+                    adsets: [{ jobId: 4, adset: null }],
+                },
+            ];
+
+            const result = countCampaignAndAdsetsAmzFb({ campaigns });
+
+            expect(result.campaignCount).toBe(1);
+            expect(result.adsetCount).toBe(0); // Since adset has a jobId
+        });
+
+        // Test Case 2: Valid input with multiple adsets and some with jobId
+        it('should count one campaign and the number of adsets without jobId', () => {
+            const campaigns = [
+                {
+                    name: '4-OUTCOME_ENGAGEMENT-Camp 1',
+                    data: { id: '120203871033130360' },
+                    adsets: [
+                        {
+                            name: '4-OUTCOME_ENGAGEMENT-Camp 1-Adset 1',
+                            data: { id: '120203871034260360' },
+                        },
+                        {
+                            name: '4-OUTCOME_ENGAGEMENT-Camp 1-Adset 1',
+                            data: { id: '120203871035910360' },
+                        },
+                        {
+                            name: '4-OUTCOME_ENGAGEMENT-Camp 1-Adset 1',
+                            data: { id: '120203871038160360' },
+                        },
+                        {
+                            name: '4-OUTCOME_ENGAGEMENT-Camp 1-Adset 1',
+                            data: {},
+                            jobId: 5,
+                        },
+                    ],
+                },
+            ];
+
+            const result = countCampaignAndAdsetsAmzFb({ campaigns });
+
+            expect(result.campaignCount).toBe(1);
+            expect(result.adsetCount).toBe(3); // Three adsets without jobId
+        });
+
+        // Test Case 3: Valid input with a campaign and an adset with lineItemId instead of jobId
+        it('should count one campaign and one adset without jobId but with lineItemId', () => {
+            const campaigns = [
+                {
+                    name: '8-Responsive eCommerce-b',
+                    data: { orderId: '578226298195109291' },
+                    adsets: [{ lineItemId: '591061514652715947' }],
+                },
+            ];
+
+            const result = countCampaignAndAdsetsAmzFb({ campaigns });
+
+            expect(result.campaignCount).toBe(1);
+            expect(result.adsetCount).toBe(1);
+        });
+
+        // Test Case 4: Valid input with empty campaigns array
+        it('should return zero counts for empty campaigns array', () => {
+            const campaigns = [];
+
+            const result = countCampaignAndAdsetsAmzFb({ campaigns });
+
+            expect(result.campaignCount).toBe(0);
+            expect(result.adsetCount).toBe(0);
         });
     });
 });


### PR DESCRIPTION
Merging this PR will fix 4 issues:

1. Updating campaign groups statuses with no allocations (incorrectly created) prevents other campaigns groups from being updated.
2. Same issue above but for campaign email notifications
3. Returned linking statuses for API enabled channels (not using BigQuery Id)
4. Ignoring API enabled channels from regular email for unlinked status (if a campaign fails during creation, it'll send emails daily because we don't currently have a way to prevent this event from triggering, we are not using BigQuery manually link)